### PR TITLE
fix mastodon website verification

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,8 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.4.0/dist/leaflet.css"
     integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA=="
     crossorigin=""/>
+
+    <link rel="me" href="https://chaos.social/@vspaceone">
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/common/Nav.js
+++ b/src/common/Nav.js
@@ -46,7 +46,7 @@ class Nav extends Component {
                         <li><a href="https://twitter.com/vspaceone" target="_blank"><i className="fab fa-twitter"></i> Twitter</a></li>
                         <li><a href="https://www.facebook.com/vspace.one" target="_blank"><i className="fab fa-facebook"></i> Facebook</a></li>
                         <li><a href="https://www.instagram.com/vspace.one/" target="_blank"><i className="fab fa-instagram"></i> Instagram</a></li>
-                        <li><a rel="me" href="https://chaos.social/@vspaceone" target="_blank"><i className="fab fa-mastodon"></i> Mastodon</a></li>
+                        <li><a href="https://chaos.social/@vspaceone" target="_blank"><i className="fab fa-mastodon"></i> Mastodon</a></li>
                         <li className="divider"></li>
                         <li><a href="/freunde" target="_blank"><i className="fab fa-users"></i>Freunde, Partner, Kooperationen</a></li>
                       </ul>


### PR DESCRIPTION
Mastodon can't access the link currently because it's in a JavaScript File and it needs to be accessible without executing JS. The verification also works if you put it in the head with a link tag so it's the best way to hide it in index.html.